### PR TITLE
EPA-351

### DIFF
--- a/src/main/java/de/health/service/cetp/AbstractCETPEventHandler.java
+++ b/src/main/java/de/health/service/cetp/AbstractCETPEventHandler.java
@@ -1,6 +1,6 @@
 package de.health.service.cetp;
 
-import de.health.service.cetp.cardlink.CardlinkWebsocketClient;
+import de.health.service.cetp.cardlink.CardlinkClient;
 import de.health.service.cetp.domain.eventservice.event.CetpEvent;
 import de.health.service.cetp.domain.eventservice.event.CetpParameter;
 import de.health.service.cetp.domain.eventservice.event.DecodeResult;
@@ -19,10 +19,10 @@ public abstract class AbstractCETPEventHandler extends ChannelInboundHandlerAdap
 
     private static final Logger log = Logger.getLogger(AbstractCETPEventHandler.class.getName());
 
-    protected CardlinkWebsocketClient cardlinkWebsocketClient;
+    protected CardlinkClient cardlinkClient;
 
-    public AbstractCETPEventHandler(CardlinkWebsocketClient cardlinkWebsocketClient) {
-        this.cardlinkWebsocketClient = cardlinkWebsocketClient;
+    public AbstractCETPEventHandler(CardlinkClient cardlinkClient) {
+        this.cardlinkClient = cardlinkClient;
     }
 
     @Override
@@ -47,10 +47,10 @@ public abstract class AbstractCETPEventHandler extends ChannelInboundHandlerAdap
         CetpEvent event = decodeResult.getEvent();
         if (event.getTopic().equals(getTopicName())) {
             try {
-                cardlinkWebsocketClient.connect();
+                cardlinkClient.connect();
                 processEvent(decodeResult.getConfigurations(), getParams(event));
             } finally {
-                cardlinkWebsocketClient.close();
+                cardlinkClient.close();
                 MDC.clear();
             }
         }

--- a/src/main/java/de/health/service/cetp/CETPServer.java
+++ b/src/main/java/de/health/service/cetp/CETPServer.java
@@ -18,6 +18,7 @@ import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.concurrent.EventExecutorGroup;
+import io.quarkus.arc.properties.IfBuildProperty;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.Startup;
 import io.quarkus.runtime.StartupEvent;
@@ -26,6 +27,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import lombok.Getter;
+import org.apache.commons.lang3.time.StopWatch;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,6 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @SuppressWarnings({"CdiInjectionPointsInspection", "unused"})
+@IfBuildProperty(name = "feature.cetp.enabled", stringValue = "true", enableIfMissing = true)
 @ApplicationScoped
 @Startup
 public class CETPServer {
@@ -74,7 +77,13 @@ public class CETPServer {
 
     // Make sure subscription manager get onStart first, before CETPServer at least!
     void onStart(@Observes @Priority(5200) StartupEvent ev) {
-        run();
+        StopWatch watch = StopWatch.createStarted();
+        try {
+            run();
+        } finally {
+            watch.stop();
+            log.info(String.format("%s %s took %s", "CETPServer", "run", watch.formatTime()));
+        }
     }
 
     void onShutdown(@Observes ShutdownEvent ev) {

--- a/src/main/java/de/health/service/check/CetpServerCheck.java
+++ b/src/main/java/de/health/service/check/CetpServerCheck.java
@@ -2,12 +2,14 @@ package de.health.service.check;
 
 import de.health.service.cetp.CETPServer;
 import de.health.service.config.api.IRuntimeConfig;
+import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import java.util.Map;
 
 @ApplicationScoped
+@IfBuildProperty(name = "feature.cetp.enabled", stringValue = "true", enableIfMissing = true)
 public class CetpServerCheck implements Check {
 
     @Inject


### PR DESCRIPTION
- features are introduced:
  * feature.cardlink.enabled=false
  * feature.fhir.enabled=false
  * feature.cetp.enabled=false
  * feature.external-pnw.enabled=false
- VauClient synchronization is fixed
- failsafe "reuseForks=false" option for using one JVM per test: bouncy castle corrupts with different Quarkus contexts and single JVM
- IT test are divided into two packages bc and non bc
- IT tests works on:
  * local epa-deployment and
  * external ePA backends