### PR TITLE
CETP server: pin secunet Konnektor cipher suites for PU (EPA-545)

### DIFF
--- a/src/main/java/de/health/service/cetp/CETPServer.java
+++ b/src/main/java/de/health/service/cetp/CETPServer.java
@@ -127,8 +127,23 @@ public class CETPServer {
                     @Override
                     public void initChannel(SocketChannel ch) {
                         try {
+                            // Pin the cipher suites the secunet Konnektor offers in its CETP
+                            // ClientHello (captured against a production Konnektor). Stay on the
+                            // stock JDK provider: the Konnektor only offers legacy rsa_pkcs1_*
+                            // handshake signature schemes (no PSS), which BCJSSE refuses to sign
+                            // in TLS 1.2 while SunJSSE signs them fine. The offered ECDHE groups
+                            // are P-256/P-384, so BouncyCastle's Brainpool support is not needed.
                             SslContext sslContext = SslContextBuilder
                                 .forServer(secretsManager.getKeyManagerFactory(config))
+                                .ciphers(java.util.List.of(
+                                    "TLS_AES_256_GCM_SHA384",
+                                    "TLS_AES_128_GCM_SHA256",
+                                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                                    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+                                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+                                    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+                                    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA"))
                                 .clientAuth(ClientAuth.NONE)
                                 .build();
 


### PR DESCRIPTION
## Context

While running epa4all against the **production** TI (profile `PU`) for a pharmacy connected via Red Medical, the CETP server's TLS handshake with the secunet Konnektor's push client failed with *"no cipher suites in common"*. Related tracking ticket: **EPA-545**. (Companion PR to `epa4all` covers the TSL/VAU/proxy fixes and the per-Konnektor CETP keystore.)

## Change

Pin exactly the cipher suites the secunet Konnektor offers in its CETP `ClientHello`. We deliberately stay on the **stock JDK TLS provider**: the Konnektor offers only legacy `rsa_pkcs1_*` handshake signature schemes (no PSS), which BCJSSE refuses to sign in TLS 1.2 while SunJSSE signs them fine — so no BouncyCastle `sslContextProvider` is set here. The offered ECDHE groups are P-256/P-384, so BC's Brainpool support isn't needed on this path.

Single, self-contained change to `CETPServer`. We can't guarantee the suite list is exhaustive for every Konnektor firmware, but it works against the production secunet Konnektor we tested; happy to widen it if you have others to check against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
